### PR TITLE
Tweaks for I2C part of workshop script

### DIFF
--- a/workshop/part-2/README.md
+++ b/workshop/part-2/README.md
@@ -83,7 +83,7 @@ the datasheet.
 ```
 >>> from microbit import i2c, display, Image
 >>> i2c.write(???)
->>> result = i2c.read(???)
+>>> read_data = i2c.read(???)
 >>> if read_data[0] == 0x5A:
 >>>     display.show(Image.HAPPY)
 ```
@@ -97,3 +97,5 @@ after the write operation without interruption (i.e. without a stop bit).
 
 - Can you find a way in the I2C documentation to not send a stop bit before
   the read operation?
+
+Are you getting a letter? What's the hex value of that letter?

--- a/workshop/part-3/README.md
+++ b/workshop/part-3/README.md
@@ -43,7 +43,7 @@ MMA8653_WHOAMI_VALUE = ??
 def check_device():
     i2c.write(MMA8653_ADDR, bytes([MMA8653_WHOAMI]), repeat=True)
     read_data = i2c.read(MMA8653_ADDR, 1)
-    if read_data[0] != MMA8653_WHOAMI_VALUE:
+    if read_data[0] == MMA8653_WHOAMI_VALUE:
         # What do we do?
         pass
 


### PR DESCRIPTION
Fix name error in repl example of part 2.

Add hint about output that we found confusing in part 2.

Keep comparison consistent in part 3 code.

Co-authored-by: Craig Loftus <craigloftus@gmail.com>